### PR TITLE
feat: Simplify automatic installation for Dokploy deployment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,9 +11,6 @@ services:
       - ./entrypoint.sh:/www/entrypoint.sh
     environment:
       - docker=true
-      - ENABLE_SQLITE=true
-      - ENABLE_REDIS=true
-      - ADMIN_ACCOUNT=admin@demo.com
     depends_on:
       - redis
     # network_mode: host

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,13 +4,7 @@ LOCK_FILE=/www/storage/installed.lock
 
 if [ ! -f "$LOCK_FILE" ]; then
   echo "🚀 Running XBoard installation..."
-  INSTALL_CMD="php artisan xboard:install --admin=${ADMIN_ACCOUNT:-admin@demo.com}"
-
-  [ "$ENABLE_SQLITE" = "true" ] && INSTALL_CMD="$INSTALL_CMD --sqlite"
-  [ "$ENABLE_REDIS" = "true" ] && INSTALL_CMD="$INSTALL_CMD --redis"
-
-  eval $INSTALL_CMD
-
+  ENABLE_SQLITE=true ENABLE_REDIS=true ADMIN_ACCOUNT=admin@demo.com php artisan xboard:install --admin=admin@demo.com
   touch "$LOCK_FILE"
 else
   echo "✅ Already installed. Skipping install."


### PR DESCRIPTION
- Streamline entrypoint.sh to use direct installation command
- Remove redundant environment variables from compose.yaml
- Use the same installation command that works manually
- Enable one-click deployment with automatic setup

🤖 Generated with [Claude Code](https://claude.ai/code)